### PR TITLE
Package RPM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,3 @@
-# .github/workflows/release.yml
 name: release
 on:
   push:
@@ -6,28 +5,45 @@ on:
 
 jobs:
   build-test-release:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Configure
-      run: cmake -S . -B build -DCMAKE_CXX_STANDARD=23 -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON
+      - name: Tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build cmake g++ rpm
 
-    - name: Build
-      run: cmake --build build -j
+      - name: Configure
+        run: cmake -S . -B build -G Ninja -DCMAKE_CXX_STANDARD=23 -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON
 
-    - name: Test
-      run: ctest --test-dir build --output-on-failure
+      - name: Build
+        run: cmake --build build -j
 
-    - name: Package headers
-      run: |
-        tar -czf bykey-${GITHUB_REF_NAME}.tar.gz include/
-        cp include/by-key/by_key.hpp single-header-by_key.hpp
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
 
-    - name: Create GitHub release
-      uses: softprops/action-gh-release@v2
-      with:
-        generate_release_notes: true
-        files: |
-          bykey-${{ github.ref_name }}.tar.gz
-          single-header-by_key.hpp
+      - name: Package artifacts
+        run: cmake --build build --target package
+
+      - name: Assemble release payload
+        run: |
+          set -euo pipefail
+          VERSION_TAG="${GITHUB_REF_NAME}"
+          VERSION_CLEAN="${VERSION_TAG#v}"
+          cp include/by-key/by_key.hpp single-header-by_key.hpp
+          TAR_PATH=$(find build -maxdepth 1 -name "bykey-${VERSION_CLEAN}*.tar.gz" | head -n1)
+          cp "${TAR_PATH}" "bykey-${VERSION_TAG}.tar.gz"
+          RPM_PATH=$(find build -maxdepth 1 -name "bykey-${VERSION_CLEAN}*.rpm" | head -n1)
+          RPM_RENAMED="bykey-${VERSION_CLEAN}.rpm"
+          cp "${RPM_PATH}" "${RPM_RENAMED}"
+          echo "RPM_UPLOAD=${RPM_RENAMED}" >> "${GITHUB_ENV}"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            bykey-${{ github.ref_name }}.tar.gz
+            single-header-by_key.hpp
+            ${{ env.RPM_UPLOAD }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # CMakeLists.txt
 cmake_minimum_required(VERSION 3.20)
 project(bykey VERSION 1.0.1 LANGUAGES CXX)
+include(GNUInstallDirs)
 add_library(bykey INTERFACE)
 target_include_directories(bykey INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_features(bykey INTERFACE cxx_std_20)
@@ -21,6 +22,30 @@ if (BUILD_EXAMPLES)
   add_example(lc_0242_valid_anagram)
   add_example(lc_1331_rank_transform)
 endif()
+
+install(
+  DIRECTORY include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+  FILES LICENSE README.md
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}
+)
+
+set(CPACK_PACKAGE_NAME "bykey")
+set(CPACK_PACKAGE_VENDOR "tremolo-delay")
+set(CPACK_PACKAGE_CONTACT "https://github.com/tremolo-delay/by-key")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
+    "Header-only C++ utilities for grouping, counting, and indexing ranges by key.")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+set(CPACK_GENERATOR "TGZ;RPM")
+set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+set(CPACK_RPM_PACKAGE_GROUP "Development/Libraries")
+set(CPACK_RPM_PACKAGE_URL "https://github.com/tremolo-delay/by-key")
+set(CPACK_RPM_PACKAGE_ARCHITECTURE "noarch")
+
+include(CPack)
 
 
 include(CTest)              # provides BUILD_TESTING option (ON by default in CI below)


### PR DESCRIPTION
Adds CPack configuration and install rules so we ship both TGZ and RPM artifacts, and updates the release workflow to build on Ubuntu, generate the packages with Ninja/CPack, and upload the new RPM alongside the existing tarball and single-header asset.